### PR TITLE
Add support for client bounds without NonClient Area on Windows

### DIFF
--- a/Sources/windows/main.cc
+++ b/Sources/windows/main.cc
@@ -197,7 +197,7 @@ Napi::Value getWindowInformation(const HWND &hwnd, const Napi::CallbackInfo &inf
 	owner.Set(Napi::String::New(env, "path"), ownerInfo.path);
 	owner.Set(Napi::String::New(env, "name"), ownerInfo.name);
 
-  // bounds window
+	// bounds window
 	Napi::Object bounds = Napi::Object::New(env);
 
 	bounds.Set(Napi::String::New(env, "x"), lpWinRect.left);
@@ -205,18 +205,18 @@ Napi::Value getWindowInformation(const HWND &hwnd, const Napi::CallbackInfo &inf
 	bounds.Set(Napi::String::New(env, "width"), lpWinRect.right - lpWinRect.left);
 	bounds.Set(Napi::String::New(env, "height"), lpWinRect.bottom - lpWinRect.top);
 
-	// bounds client
+	// bounds content
 	POINT rectTopLeft = {lpClientRect.left, lpClientRect.top};
 	ClientToScreen(hwnd, &rectTopLeft);
 	POINT rectBottomRight = {lpClientRect.right, lpClientRect.bottom};
 	ClientToScreen(hwnd, &rectBottomRight);
 
-	Napi::Object boundsClient = Napi::Object::New(env);
+	Napi::Object contentBounds = Napi::Object::New(env);
 
-	boundsClient.Set(Napi::String::New(env, "x"), rectTopLeft.x);
-	boundsClient.Set(Napi::String::New(env, "y"), rectTopLeft.y);
-	boundsClient.Set(Napi::String::New(env, "width"), rectBottomRight.x - rectTopLeft.x);
-	boundsClient.Set(Napi::String::New(env, "height"), rectBottomRight.y - rectTopLeft.y);
+	contentBounds.Set(Napi::String::New(env, "x"), rectTopLeft.x);
+	contentBounds.Set(Napi::String::New(env, "y"), rectTopLeft.y);
+	contentBounds.Set(Napi::String::New(env, "width"), rectBottomRight.x - rectTopLeft.x);
+	contentBounds.Set(Napi::String::New(env, "height"), rectBottomRight.y - rectTopLeft.y);
 
 	Napi::Object activeWinObj = Napi::Object::New(env);
 
@@ -225,7 +225,7 @@ Napi::Value getWindowInformation(const HWND &hwnd, const Napi::CallbackInfo &inf
 	activeWinObj.Set(Napi::String::New(env, "title"), getWindowTitle(hwnd));
 	activeWinObj.Set(Napi::String::New(env, "owner"), owner);
 	activeWinObj.Set(Napi::String::New(env, "bounds"), bounds);
-	activeWinObj.Set(Napi::String::New(env, "boundsClient"), boundsClient);
+	activeWinObj.Set(Napi::String::New(env, "contentBounds"), contentBounds);
 	activeWinObj.Set(Napi::String::New(env, "memoryUsage"), memoryCounter.WorkingSetSize);
 
 	return activeWinObj;

--- a/index.d.ts
+++ b/index.d.ts
@@ -97,7 +97,7 @@ export type WindowsResult = {
 	platform: 'windows';
 
 	/**
-	Content position and size without Nonclient Area
+	Window content position and size, which excludes the title bar, menu bar, and frame.
 	*/
 	contentBounds: {
 		x: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -97,9 +97,9 @@ export type WindowsResult = {
 	platform: 'windows';
 
 	/**
-		 Client position and size.
-	 */
-	boundsClient: {
+	Content position and size without Nonclient Area
+	*/
+	contentBounds: {
 		x: number;
 		y: number;
 		width: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,6 +95,16 @@ export type LinuxResult = {
 
 export type WindowsResult = {
 	platform: 'windows';
+
+	/**
+		 Client position and size.
+	 */
+	boundsClient: {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+	};
 } & BaseResult;
 
 export type Result = MacOSResult | LinuxResult | WindowsResult;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -39,9 +39,11 @@ if (result) {
 		expectType<string | undefined>(result.url);
 	} else if (result.platform === 'linux') {
 		expectType<LinuxResult>(result);
-		expectError(result.owner.bundleId);
 	} else {
 		expectType<WindowsResult>(result);
-		expectError(result.owner.bundleId);
+		expectType<number>(result.boundsClient.x);
+		expectType<number>(result.boundsClient.y);
+		expectType<number>(result.boundsClient.width);
+		expectType<number>(result.boundsClient.height);
 	}
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -41,9 +41,9 @@ if (result) {
 		expectType<LinuxResult>(result);
 	} else {
 		expectType<WindowsResult>(result);
-		expectType<number>(result.boundsClient.x);
-		expectType<number>(result.boundsClient.y);
-		expectType<number>(result.boundsClient.width);
-		expectType<number>(result.boundsClient.height);
+		expectType<number>(result.contentBounds.x);
+		expectType<number>(result.contentBounds.y);
+		expectType<number>(result.contentBounds.width);
+		expectType<number>(result.contentBounds.height);
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Returns a `Promise<object>` with the result, or `Promise<undefined>` if there is
 	- `y` *(number)*
 	- `width` *(number)*
 	- `height` *(number)*
-- `contentBounds` *(Object)* - Client position and size without Nonclient Area *(Windows only)*
+- `contentBounds` *(Object)* - Window content position and size, which excludes the title bar, menu bar, and frame *(Windows only)*
 	- `x` *(number)*
 	- `y` *(number)*
 	- `width` *(number)*

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Returns a `Promise<object>` with the result, or `Promise<undefined>` if there is
 	- `y` *(number)*
 	- `width` *(number)*
 	- `height` *(number)*
-- `boundsClient` *(Object)* - Client position and size without Nonclient Area *(Windows only)*
+- `contentBounds` *(Object)* - Client position and size without Nonclient Area *(Windows only)*
 	- `x` *(number)*
 	- `y` *(number)*
 	- `width` *(number)*

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,11 @@ Returns a `Promise<object>` with the result, or `Promise<undefined>` if there is
 	- `y` *(number)*
 	- `width` *(number)*
 	- `height` *(number)*
+- `boundsClient` *(Object)* - Client position and size without Nonclient Area *(Windows only)*
+	- `x` *(number)*
+	- `y` *(number)*
+	- `width` *(number)*
+	- `height` *(number)*
 - `owner` *(Object)* - App that owns the window
 	- `name` *(string)* - Name of the app
 	- `processId` *(number)* - Process identifier


### PR DESCRIPTION
Add support for `activeWindow()` to return `clientBounds` which is the bounds of the client area of the window. 

The client area of the window does not include Nonclient Area such as the title bar, menu bar, or window frame.  

This is useful if the client position and size is used to add overlay windows and dialogs on top of the activeWindow. 

The change is only for Windows platform and only the relevant typescript definitions and tests were updated. 
