### PR TITLE
fix: handle invalid UTF-8 characters in application name on Linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -35,10 +35,8 @@ const parseLinux = ({stdout, boundsStdout, activeWindowId}) => {
 
 	const windowIdProperty = 'WM_CLIENT_LEADER(WINDOW)';
 	const resultKeys = Object.keys(result);
-	const windowId
-		= (resultKeys.indexOf(windowIdProperty) > 0
-			&& Number.parseInt(result[windowIdProperty].split('#').pop(), 16))
-		|| activeWindowId;
+	const windowId = (resultKeys.indexOf(windowIdProperty) > 0
+		&& Number.parseInt(result[windowIdProperty].split('#').pop(), 16)) || activeWindowId;
 
 	const processId = Number.parseInt(result['_NET_WM_PID(CARDINAL)'], 10);
 
@@ -50,21 +48,22 @@ const parseLinux = ({stdout, boundsStdout, activeWindowId}) => {
 		platform: 'linux',
 		title: (() => {
 			try {
-				const rawTitle
-					= result['_NET_WM_NAME(UTF8_STRING)'] || result['WM_NAME(STRING)'];
+				const rawTitle = result['_NET_WM_NAME(UTF8_STRING)'] || result['WM_NAME(STRING)'];
 				if (!rawTitle) {
 					return null;
 				}
 
+				const cleanTitle = rawTitle
+					.replaceAll(/\\(\d{3})/g, (_, code) =>
+						String.fromCharCode(Number.parseInt(code, 8)), // eslint-disable-line unicorn/prefer-code-point
+					)
+					.replaceAll(/^"|"$/g, '')
+					.replaceAll('\\\\', '\\');
+
 				try {
-					return JSON.parse(rawTitle);
+					return JSON.parse(cleanTitle);
 				} catch {
-					return rawTitle
-						.replaceAll(/\\(\d{3})/g, (_, code) =>
-							String.fromCharCode(Number.parseInt(code, 8)), // eslint-disable-line unicorn/prefer-code-point
-						)
-						.replaceAll(/^"|"$/g, '')
-						.replaceAll('\\\\', '\\');
+					return cleanTitle;
 				}
 			} catch {
 				return null;
@@ -74,10 +73,20 @@ const parseLinux = ({stdout, boundsStdout, activeWindowId}) => {
 		owner: {
 			name: (() => {
 				try {
-					return JSON.parse(result['WM_CLASS(STRING)'].split(',').pop());
+					const rawOwnerName = result['WM_CLASS(STRING)'].split(',').pop();
+					if (!rawOwnerName) {
+						return null;
+					}
+
+					const cleanOwnerName = rawOwnerName.replaceAll(/^"|"$/g, '');
+
+					try {
+						return JSON.parse(cleanOwnerName);
+					} catch {
+						return cleanOwnerName;
+					}
 				} catch {
-					const className = result['WM_CLASS(STRING)'].split(',').pop();
-					return className ? className.replaceAll(/^"|"$/g, '') : null;
+					return null;
 				}
 			})(),
 			processId,
@@ -91,8 +100,7 @@ const parseLinux = ({stdout, boundsStdout, activeWindowId}) => {
 	};
 };
 
-const getActiveWindowId = activeWindowIdStdout =>
-	Number.parseInt(activeWindowIdStdout.split('\t')[1], 16);
+const getActiveWindowId = activeWindowIdStdout => Number.parseInt(activeWindowIdStdout.split('\t')[1], 16);
 
 const getMemoryUsageByPid = async pid => {
 	const statm = await readFile(`/proc/${pid}/statm`, 'utf8');
@@ -114,9 +122,7 @@ const getPathByPidSync = pid => {
 
 async function getWindowInformation(windowId) {
 	const [{stdout}, {stdout: boundsStdout}] = await Promise.all([
-		execFile(xpropBinary, [...xpropDetailsArguments, windowId], {
-			env: {...process.env, LC_ALL: 'C.utf8'},
-		}),
+		execFile(xpropBinary, [...xpropDetailsArguments, windowId], {env: {...process.env, LC_ALL: 'C.utf8'}}),
 		execFile(xwininfoBinary, [...xpropDetailsArguments, windowId]),
 	]);
 
@@ -135,16 +141,8 @@ async function getWindowInformation(windowId) {
 }
 
 function getWindowInformationSync(windowId) {
-	const stdout = childProcess.execFileSync(
-		xpropBinary,
-		[...xpropDetailsArguments, windowId],
-		{encoding: 'utf8', env: {...process.env, LC_ALL: 'C.utf8'}},
-	);
-	const boundsStdout = childProcess.execFileSync(
-		xwininfoBinary,
-		[...xpropDetailsArguments, windowId],
-		{encoding: 'utf8'},
-	);
+	const stdout = childProcess.execFileSync(xpropBinary, [...xpropDetailsArguments, windowId], {encoding: 'utf8', env: {...process.env, LC_ALL: 'C.utf8'}});
+	const boundsStdout = childProcess.execFileSync(xwininfoBinary, [...xpropDetailsArguments, windowId], {encoding: 'utf8'});
 
 	const data = parseLinux({
 		activeWindowId: windowId,
@@ -158,10 +156,7 @@ function getWindowInformationSync(windowId) {
 
 export async function activeWindow() {
 	try {
-		const {stdout: activeWindowIdStdout} = await execFile(
-			xpropBinary,
-			xpropActiveArguments,
-		);
+		const {stdout: activeWindowIdStdout} = await execFile(xpropBinary, xpropActiveArguments);
 		const activeWindowId = getActiveWindowId(activeWindowIdStdout);
 
 		if (!activeWindowId) {
@@ -176,11 +171,7 @@ export async function activeWindow() {
 
 export function activeWindowSync() {
 	try {
-		const activeWindowIdStdout = childProcess.execFileSync(
-			xpropBinary,
-			xpropActiveArguments,
-			{encoding: 'utf8'},
-		);
+		const activeWindowIdStdout = childProcess.execFileSync(xpropBinary, xpropActiveArguments, {encoding: 'utf8'});
 		const activeWindowId = getActiveWindowId(activeWindowIdStdout);
 
 		if (!activeWindowId) {
@@ -195,17 +186,10 @@ export function activeWindowSync() {
 
 export async function openWindows() {
 	try {
-		const {stdout: openWindowIdStdout} = await execFile(
-			xpropBinary,
-			xpropOpenArguments,
-		);
+		const {stdout: openWindowIdStdout} = await execFile(xpropBinary, xpropOpenArguments);
 
 		// Get open windows Ids
-		const windowsIds = openWindowIdStdout
-			.split('#')[1]
-			.trim()
-			.replace('\n', '')
-			.split(',');
+		const windowsIds = openWindowIdStdout.split('#')[1].trim().replace('\n', '').split(',');
 
 		if (!windowsIds || windowsIds.length === 0) {
 			return;
@@ -214,9 +198,7 @@ export async function openWindows() {
 		const openWindows = [];
 
 		for await (const windowId of windowsIds) {
-			openWindows.push(
-				await getWindowInformation(Number.parseInt(windowId, 16)),
-			);
+			openWindows.push(await getWindowInformation(Number.parseInt(windowId, 16)));
 		}
 
 		return openWindows;
@@ -227,16 +209,8 @@ export async function openWindows() {
 
 export function openWindowsSync() {
 	try {
-		const openWindowIdStdout = childProcess.execFileSync(
-			xpropBinary,
-			xpropOpenArguments,
-			{encoding: 'utf8'},
-		);
-		const windowsIds = openWindowIdStdout
-			.split('#')[1]
-			.trim()
-			.replace('\n', '')
-			.split(',');
+		const openWindowIdStdout = childProcess.execFileSync(xpropBinary, xpropOpenArguments, {encoding: 'utf8'});
+		const windowsIds = openWindowIdStdout.split('#')[1].trim().replace('\n', '').split(',');
 
 		if (!windowsIds || windowsIds.length === 0) {
 			return;
@@ -245,9 +219,7 @@ export function openWindowsSync() {
 		const openWindows = [];
 
 		for (const windowId of windowsIds) {
-			const windowInformation = getWindowInformationSync(
-				Number.parseInt(windowId, 16),
-			);
+			const windowInformation = getWindowInformationSync(Number.parseInt(windowId, 16));
 			openWindows.push(windowInformation);
 		}
 

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,192 +1,256 @@
-import process from 'node:process';
-import {promisify} from 'node:util';
-import fs from 'node:fs';
-import childProcess from 'node:child_process';
+import process from "node:process";
+import { promisify } from "node:util";
+import fs from "node:fs";
+import childProcess from "node:child_process";
 
 const execFile = promisify(childProcess.execFile);
 const readFile = promisify(fs.readFile);
 const readlink = promisify(fs.readlink);
 
-const xpropBinary = 'xprop';
-const xwininfoBinary = 'xwininfo';
-const xpropActiveArguments = ['-root', '\t$0', '_NET_ACTIVE_WINDOW'];
-const xpropOpenArguments = ['-root', '_NET_CLIENT_LIST_STACKING'];
-const xpropDetailsArguments = ['-id'];
+const xpropBinary = "xprop";
+const xwininfoBinary = "xwininfo";
+const xpropActiveArguments = ["-root", "\t$0", "_NET_ACTIVE_WINDOW"];
+const xpropOpenArguments = ["-root", "_NET_CLIENT_LIST_STACKING"];
+const xpropDetailsArguments = ["-id"];
 
-const processOutput = output => {
-	const result = {};
+const processOutput = (output) => {
+  const result = {};
 
-	for (const row of output.trim().split('\n')) {
-		if (row.includes('=')) {
-			const [key, value] = row.split('=');
-			result[key.trim()] = value.trim();
-		} else if (row.includes(':')) {
-			const [key, value] = row.split(':');
-			result[key.trim()] = value.trim();
-		}
-	}
+  for (const row of output.trim().split("\n")) {
+    if (row.includes("=")) {
+      const [key, value] = row.split("=");
+      result[key.trim()] = value.trim();
+    } else if (row.includes(":")) {
+      const [key, value] = row.split(":");
+      result[key.trim()] = value.trim();
+    }
+  }
 
-	return result;
+  return result;
 };
 
-const parseLinux = ({stdout, boundsStdout, activeWindowId}) => {
-	const result = processOutput(stdout);
-	const bounds = processOutput(boundsStdout);
+const parseLinux = ({ stdout, boundsStdout, activeWindowId }) => {
+  const result = processOutput(stdout);
+  const bounds = processOutput(boundsStdout);
 
-	const windowIdProperty = 'WM_CLIENT_LEADER(WINDOW)';
-	const resultKeys = Object.keys(result);
-	const windowId = (resultKeys.indexOf(windowIdProperty) > 0
-		&& Number.parseInt(result[windowIdProperty].split('#').pop(), 16)) || activeWindowId;
+  const windowIdProperty = "WM_CLIENT_LEADER(WINDOW)";
+  const resultKeys = Object.keys(result);
+  const windowId =
+    (resultKeys.indexOf(windowIdProperty) > 0 &&
+      Number.parseInt(result[windowIdProperty].split("#").pop(), 16)) ||
+    activeWindowId;
 
-	const processId = Number.parseInt(result['_NET_WM_PID(CARDINAL)'], 10);
+  const processId = Number.parseInt(result["_NET_WM_PID(CARDINAL)"], 10);
 
-	if (Number.isNaN(processId)) {
-		throw new Error('Failed to parse process ID'); // eslint-disable-line unicorn/prefer-type-error
-	}
+  if (Number.isNaN(processId)) {
+    throw new Error("Failed to parse process ID"); // eslint-disable-line unicorn/prefer-type-error
+  }
 
-	return {
-		platform: 'linux',
-		title: JSON.parse(result['_NET_WM_NAME(UTF8_STRING)'] || result['WM_NAME(STRING)']) || null,
-		id: windowId,
-		owner: {
-			name: JSON.parse(result['WM_CLASS(STRING)'].split(',').pop()),
-			processId,
-		},
-		bounds: {
-			x: Number.parseInt(bounds['Absolute upper-left X'], 10),
-			y: Number.parseInt(bounds['Absolute upper-left Y'], 10),
-			width: Number.parseInt(bounds.Width, 10),
-			height: Number.parseInt(bounds.Height, 10),
-		},
-	};
+  return {
+    platform: "linux",
+    title: (() => {
+      try {
+        const rawTitle =
+          result["_NET_WM_NAME(UTF8_STRING)"] || result["WM_NAME(STRING)"];
+        if (!rawTitle) return null;
+        try {
+          return JSON.parse(rawTitle);
+        } catch {
+          return rawTitle
+            .replace(/\\([0-9]{3})/g, (_, code) =>
+              String.fromCharCode(parseInt(code, 8))
+            )
+            .replace(/^"|"$/g, "")
+            .replace(/\\\\/g, "\\");
+        }
+      } catch {
+        return null;
+      }
+    })(),
+    id: windowId,
+    owner: {
+      name: (() => {
+        try {
+          return JSON.parse(result["WM_CLASS(STRING)"].split(",").pop());
+        } catch {
+          const className = result["WM_CLASS(STRING)"].split(",").pop();
+          return className ? className.replace(/^"|"$/g, "") : null;
+        }
+      })(),
+      processId,
+    },
+    bounds: {
+      x: Number.parseInt(bounds["Absolute upper-left X"], 10),
+      y: Number.parseInt(bounds["Absolute upper-left Y"], 10),
+      width: Number.parseInt(bounds.Width, 10),
+      height: Number.parseInt(bounds.Height, 10),
+    },
+  };
 };
 
-const getActiveWindowId = activeWindowIdStdout => Number.parseInt(activeWindowIdStdout.split('\t')[1], 16);
+const getActiveWindowId = (activeWindowIdStdout) =>
+  Number.parseInt(activeWindowIdStdout.split("\t")[1], 16);
 
-const getMemoryUsageByPid = async pid => {
-	const statm = await readFile(`/proc/${pid}/statm`, 'utf8');
-	return Number.parseInt(statm.split(' ')[1], 10) * 4096;
+const getMemoryUsageByPid = async (pid) => {
+  const statm = await readFile(`/proc/${pid}/statm`, "utf8");
+  return Number.parseInt(statm.split(" ")[1], 10) * 4096;
 };
 
-const getMemoryUsageByPidSync = pid => {
-	const statm = fs.readFileSync(`/proc/${pid}/statm`, 'utf8');
-	return Number.parseInt(statm.split(' ')[1], 10) * 4096;
+const getMemoryUsageByPidSync = (pid) => {
+  const statm = fs.readFileSync(`/proc/${pid}/statm`, "utf8");
+  return Number.parseInt(statm.split(" ")[1], 10) * 4096;
 };
 
-const getPathByPid = pid => readlink(`/proc/${pid}/exe`);
+const getPathByPid = (pid) => readlink(`/proc/${pid}/exe`);
 
-const getPathByPidSync = pid => {
-	try {
-		return fs.readlinkSync(`/proc/${pid}/exe`);
-	} catch {}
+const getPathByPidSync = (pid) => {
+  try {
+    return fs.readlinkSync(`/proc/${pid}/exe`);
+  } catch {}
 };
 
 async function getWindowInformation(windowId) {
-	const [{stdout}, {stdout: boundsStdout}] = await Promise.all([
-		execFile(xpropBinary, [...xpropDetailsArguments, windowId], {env: {...process.env, LC_ALL: 'C.utf8'}}),
-		execFile(xwininfoBinary, [...xpropDetailsArguments, windowId]),
-	]);
+  const [{ stdout }, { stdout: boundsStdout }] = await Promise.all([
+    execFile(xpropBinary, [...xpropDetailsArguments, windowId], {
+      env: { ...process.env, LC_ALL: "C.utf8" },
+    }),
+    execFile(xwininfoBinary, [...xpropDetailsArguments, windowId]),
+  ]);
 
-	const data = parseLinux({
-		activeWindowId: windowId,
-		boundsStdout,
-		stdout,
-	});
-	const [memoryUsage, path] = await Promise.all([
-		getMemoryUsageByPid(data.owner.processId),
-		getPathByPid(data.owner.processId).catch(() => {}),
-	]);
-	data.memoryUsage = memoryUsage;
-	data.owner.path = path;
-	return data;
+  const data = parseLinux({
+    activeWindowId: windowId,
+    boundsStdout,
+    stdout,
+  });
+  const [memoryUsage, path] = await Promise.all([
+    getMemoryUsageByPid(data.owner.processId),
+    getPathByPid(data.owner.processId).catch(() => {}),
+  ]);
+  data.memoryUsage = memoryUsage;
+  data.owner.path = path;
+  return data;
 }
 
 function getWindowInformationSync(windowId) {
-	const stdout = childProcess.execFileSync(xpropBinary, [...xpropDetailsArguments, windowId], {encoding: 'utf8', env: {...process.env, LC_ALL: 'C.utf8'}});
-	const boundsStdout = childProcess.execFileSync(xwininfoBinary, [...xpropDetailsArguments, windowId], {encoding: 'utf8'});
+  const stdout = childProcess.execFileSync(
+    xpropBinary,
+    [...xpropDetailsArguments, windowId],
+    { encoding: "utf8", env: { ...process.env, LC_ALL: "C.utf8" } }
+  );
+  const boundsStdout = childProcess.execFileSync(
+    xwininfoBinary,
+    [...xpropDetailsArguments, windowId],
+    { encoding: "utf8" }
+  );
 
-	const data = parseLinux({
-		activeWindowId: windowId,
-		boundsStdout,
-		stdout,
-	});
-	data.memoryUsage = getMemoryUsageByPidSync(data.owner.processId);
-	data.owner.path = getPathByPidSync(data.owner.processId);
-	return data;
+  const data = parseLinux({
+    activeWindowId: windowId,
+    boundsStdout,
+    stdout,
+  });
+  data.memoryUsage = getMemoryUsageByPidSync(data.owner.processId);
+  data.owner.path = getPathByPidSync(data.owner.processId);
+  return data;
 }
 
 export async function activeWindow() {
-	try {
-		const {stdout: activeWindowIdStdout} = await execFile(xpropBinary, xpropActiveArguments);
-		const activeWindowId = getActiveWindowId(activeWindowIdStdout);
+  try {
+    const { stdout: activeWindowIdStdout } = await execFile(
+      xpropBinary,
+      xpropActiveArguments
+    );
+    const activeWindowId = getActiveWindowId(activeWindowIdStdout);
 
-		if (!activeWindowId) {
-			return;
-		}
+    if (!activeWindowId) {
+      return;
+    }
 
-		return getWindowInformation(activeWindowId);
-	} catch {
-		return undefined;
-	}
+    return getWindowInformation(activeWindowId);
+  } catch {
+    return undefined;
+  }
 }
 
 export function activeWindowSync() {
-	try {
-		const activeWindowIdStdout = childProcess.execFileSync(xpropBinary, xpropActiveArguments, {encoding: 'utf8'});
-		const activeWindowId = getActiveWindowId(activeWindowIdStdout);
+  try {
+    const activeWindowIdStdout = childProcess.execFileSync(
+      xpropBinary,
+      xpropActiveArguments,
+      { encoding: "utf8" }
+    );
+    const activeWindowId = getActiveWindowId(activeWindowIdStdout);
 
-		if (!activeWindowId) {
-			return;
-		}
+    if (!activeWindowId) {
+      return;
+    }
 
-		return getWindowInformationSync(activeWindowId);
-	} catch {
-		return undefined;
-	}
+    return getWindowInformationSync(activeWindowId);
+  } catch {
+    return undefined;
+  }
 }
 
 export async function openWindows() {
-	try {
-		const {stdout: openWindowIdStdout} = await execFile(xpropBinary, xpropOpenArguments);
+  try {
+    const { stdout: openWindowIdStdout } = await execFile(
+      xpropBinary,
+      xpropOpenArguments
+    );
 
-		// Get open windows Ids
-		const windowsIds = openWindowIdStdout.split('#')[1].trim().replace('\n', '').split(',');
+    // Get open windows Ids
+    const windowsIds = openWindowIdStdout
+      .split("#")[1]
+      .trim()
+      .replace("\n", "")
+      .split(",");
 
-		if (!windowsIds || windowsIds.length === 0) {
-			return;
-		}
+    if (!windowsIds || windowsIds.length === 0) {
+      return;
+    }
 
-		const openWindows = [];
+    const openWindows = [];
 
-		for await (const windowId of windowsIds) {
-			openWindows.push(await getWindowInformation(Number.parseInt(windowId, 16)));
-		}
+    for await (const windowId of windowsIds) {
+      openWindows.push(
+        await getWindowInformation(Number.parseInt(windowId, 16))
+      );
+    }
 
-		return openWindows;
-	} catch {
-		return undefined;
-	}
+    return openWindows;
+  } catch {
+    return undefined;
+  }
 }
 
 export function openWindowsSync() {
-	try {
-		const openWindowIdStdout = childProcess.execFileSync(xpropBinary, xpropOpenArguments, {encoding: 'utf8'});
-		const windowsIds = openWindowIdStdout.split('#')[1].trim().replace('\n', '').split(',');
+  try {
+    const openWindowIdStdout = childProcess.execFileSync(
+      xpropBinary,
+      xpropOpenArguments,
+      { encoding: "utf8" }
+    );
+    const windowsIds = openWindowIdStdout
+      .split("#")[1]
+      .trim()
+      .replace("\n", "")
+      .split(",");
 
-		if (!windowsIds || windowsIds.length === 0) {
-			return;
-		}
+    if (!windowsIds || windowsIds.length === 0) {
+      return;
+    }
 
-		const openWindows = [];
+    const openWindows = [];
 
-		for (const windowId of windowsIds) {
-			const windowInformation = getWindowInformationSync(Number.parseInt(windowId, 16));
-			openWindows.push(windowInformation);
-		}
+    for (const windowId of windowsIds) {
+      const windowInformation = getWindowInformationSync(
+        Number.parseInt(windowId, 16)
+      );
+      openWindows.push(windowInformation);
+    }
 
-		return openWindows;
-	} catch (error) {
-		console.log(error);
-		return undefined;
-	}
+    return openWindows;
+  } catch (error) {
+    console.log(error);
+    return undefined;
+  }
 }

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,256 +1,259 @@
-import process from "node:process";
-import { promisify } from "node:util";
-import fs from "node:fs";
-import childProcess from "node:child_process";
+import process from 'node:process';
+import {promisify} from 'node:util';
+import fs from 'node:fs';
+import childProcess from 'node:child_process';
 
 const execFile = promisify(childProcess.execFile);
 const readFile = promisify(fs.readFile);
 const readlink = promisify(fs.readlink);
 
-const xpropBinary = "xprop";
-const xwininfoBinary = "xwininfo";
-const xpropActiveArguments = ["-root", "\t$0", "_NET_ACTIVE_WINDOW"];
-const xpropOpenArguments = ["-root", "_NET_CLIENT_LIST_STACKING"];
-const xpropDetailsArguments = ["-id"];
+const xpropBinary = 'xprop';
+const xwininfoBinary = 'xwininfo';
+const xpropActiveArguments = ['-root', '\t$0', '_NET_ACTIVE_WINDOW'];
+const xpropOpenArguments = ['-root', '_NET_CLIENT_LIST_STACKING'];
+const xpropDetailsArguments = ['-id'];
 
-const processOutput = (output) => {
-  const result = {};
+const processOutput = output => {
+	const result = {};
 
-  for (const row of output.trim().split("\n")) {
-    if (row.includes("=")) {
-      const [key, value] = row.split("=");
-      result[key.trim()] = value.trim();
-    } else if (row.includes(":")) {
-      const [key, value] = row.split(":");
-      result[key.trim()] = value.trim();
-    }
-  }
+	for (const row of output.trim().split('\n')) {
+		if (row.includes('=')) {
+			const [key, value] = row.split('=');
+			result[key.trim()] = value.trim();
+		} else if (row.includes(':')) {
+			const [key, value] = row.split(':');
+			result[key.trim()] = value.trim();
+		}
+	}
 
-  return result;
+	return result;
 };
 
-const parseLinux = ({ stdout, boundsStdout, activeWindowId }) => {
-  const result = processOutput(stdout);
-  const bounds = processOutput(boundsStdout);
+const parseLinux = ({stdout, boundsStdout, activeWindowId}) => {
+	const result = processOutput(stdout);
+	const bounds = processOutput(boundsStdout);
 
-  const windowIdProperty = "WM_CLIENT_LEADER(WINDOW)";
-  const resultKeys = Object.keys(result);
-  const windowId =
-    (resultKeys.indexOf(windowIdProperty) > 0 &&
-      Number.parseInt(result[windowIdProperty].split("#").pop(), 16)) ||
-    activeWindowId;
+	const windowIdProperty = 'WM_CLIENT_LEADER(WINDOW)';
+	const resultKeys = Object.keys(result);
+	const windowId
+		= (resultKeys.indexOf(windowIdProperty) > 0
+			&& Number.parseInt(result[windowIdProperty].split('#').pop(), 16))
+		|| activeWindowId;
 
-  const processId = Number.parseInt(result["_NET_WM_PID(CARDINAL)"], 10);
+	const processId = Number.parseInt(result['_NET_WM_PID(CARDINAL)'], 10);
 
-  if (Number.isNaN(processId)) {
-    throw new Error("Failed to parse process ID"); // eslint-disable-line unicorn/prefer-type-error
-  }
+	if (Number.isNaN(processId)) {
+		throw new Error('Failed to parse process ID'); // eslint-disable-line unicorn/prefer-type-error
+	}
 
-  return {
-    platform: "linux",
-    title: (() => {
-      try {
-        const rawTitle =
-          result["_NET_WM_NAME(UTF8_STRING)"] || result["WM_NAME(STRING)"];
-        if (!rawTitle) return null;
-        try {
-          return JSON.parse(rawTitle);
-        } catch {
-          return rawTitle
-            .replace(/\\([0-9]{3})/g, (_, code) =>
-              String.fromCharCode(parseInt(code, 8))
-            )
-            .replace(/^"|"$/g, "")
-            .replace(/\\\\/g, "\\");
-        }
-      } catch {
-        return null;
-      }
-    })(),
-    id: windowId,
-    owner: {
-      name: (() => {
-        try {
-          return JSON.parse(result["WM_CLASS(STRING)"].split(",").pop());
-        } catch {
-          const className = result["WM_CLASS(STRING)"].split(",").pop();
-          return className ? className.replace(/^"|"$/g, "") : null;
-        }
-      })(),
-      processId,
-    },
-    bounds: {
-      x: Number.parseInt(bounds["Absolute upper-left X"], 10),
-      y: Number.parseInt(bounds["Absolute upper-left Y"], 10),
-      width: Number.parseInt(bounds.Width, 10),
-      height: Number.parseInt(bounds.Height, 10),
-    },
-  };
+	return {
+		platform: 'linux',
+		title: (() => {
+			try {
+				const rawTitle
+					= result['_NET_WM_NAME(UTF8_STRING)'] || result['WM_NAME(STRING)'];
+				if (!rawTitle) {
+					return null;
+				}
+
+				try {
+					return JSON.parse(rawTitle);
+				} catch {
+					return rawTitle
+						.replaceAll(/\\(\d{3})/g, (_, code) =>
+							String.fromCharCode(Number.parseInt(code, 8)), // eslint-disable-line unicorn/prefer-code-point
+						)
+						.replaceAll(/^"|"$/g, '')
+						.replaceAll('\\\\', '\\');
+				}
+			} catch {
+				return null;
+			}
+		})(),
+		id: windowId,
+		owner: {
+			name: (() => {
+				try {
+					return JSON.parse(result['WM_CLASS(STRING)'].split(',').pop());
+				} catch {
+					const className = result['WM_CLASS(STRING)'].split(',').pop();
+					return className ? className.replaceAll(/^"|"$/g, '') : null;
+				}
+			})(),
+			processId,
+		},
+		bounds: {
+			x: Number.parseInt(bounds['Absolute upper-left X'], 10),
+			y: Number.parseInt(bounds['Absolute upper-left Y'], 10),
+			width: Number.parseInt(bounds.Width, 10),
+			height: Number.parseInt(bounds.Height, 10),
+		},
+	};
 };
 
-const getActiveWindowId = (activeWindowIdStdout) =>
-  Number.parseInt(activeWindowIdStdout.split("\t")[1], 16);
+const getActiveWindowId = activeWindowIdStdout =>
+	Number.parseInt(activeWindowIdStdout.split('\t')[1], 16);
 
-const getMemoryUsageByPid = async (pid) => {
-  const statm = await readFile(`/proc/${pid}/statm`, "utf8");
-  return Number.parseInt(statm.split(" ")[1], 10) * 4096;
+const getMemoryUsageByPid = async pid => {
+	const statm = await readFile(`/proc/${pid}/statm`, 'utf8');
+	return Number.parseInt(statm.split(' ')[1], 10) * 4096;
 };
 
-const getMemoryUsageByPidSync = (pid) => {
-  const statm = fs.readFileSync(`/proc/${pid}/statm`, "utf8");
-  return Number.parseInt(statm.split(" ")[1], 10) * 4096;
+const getMemoryUsageByPidSync = pid => {
+	const statm = fs.readFileSync(`/proc/${pid}/statm`, 'utf8');
+	return Number.parseInt(statm.split(' ')[1], 10) * 4096;
 };
 
-const getPathByPid = (pid) => readlink(`/proc/${pid}/exe`);
+const getPathByPid = pid => readlink(`/proc/${pid}/exe`);
 
-const getPathByPidSync = (pid) => {
-  try {
-    return fs.readlinkSync(`/proc/${pid}/exe`);
-  } catch {}
+const getPathByPidSync = pid => {
+	try {
+		return fs.readlinkSync(`/proc/${pid}/exe`);
+	} catch {}
 };
 
 async function getWindowInformation(windowId) {
-  const [{ stdout }, { stdout: boundsStdout }] = await Promise.all([
-    execFile(xpropBinary, [...xpropDetailsArguments, windowId], {
-      env: { ...process.env, LC_ALL: "C.utf8" },
-    }),
-    execFile(xwininfoBinary, [...xpropDetailsArguments, windowId]),
-  ]);
+	const [{stdout}, {stdout: boundsStdout}] = await Promise.all([
+		execFile(xpropBinary, [...xpropDetailsArguments, windowId], {
+			env: {...process.env, LC_ALL: 'C.utf8'},
+		}),
+		execFile(xwininfoBinary, [...xpropDetailsArguments, windowId]),
+	]);
 
-  const data = parseLinux({
-    activeWindowId: windowId,
-    boundsStdout,
-    stdout,
-  });
-  const [memoryUsage, path] = await Promise.all([
-    getMemoryUsageByPid(data.owner.processId),
-    getPathByPid(data.owner.processId).catch(() => {}),
-  ]);
-  data.memoryUsage = memoryUsage;
-  data.owner.path = path;
-  return data;
+	const data = parseLinux({
+		activeWindowId: windowId,
+		boundsStdout,
+		stdout,
+	});
+	const [memoryUsage, path] = await Promise.all([
+		getMemoryUsageByPid(data.owner.processId),
+		getPathByPid(data.owner.processId).catch(() => {}),
+	]);
+	data.memoryUsage = memoryUsage;
+	data.owner.path = path;
+	return data;
 }
 
 function getWindowInformationSync(windowId) {
-  const stdout = childProcess.execFileSync(
-    xpropBinary,
-    [...xpropDetailsArguments, windowId],
-    { encoding: "utf8", env: { ...process.env, LC_ALL: "C.utf8" } }
-  );
-  const boundsStdout = childProcess.execFileSync(
-    xwininfoBinary,
-    [...xpropDetailsArguments, windowId],
-    { encoding: "utf8" }
-  );
+	const stdout = childProcess.execFileSync(
+		xpropBinary,
+		[...xpropDetailsArguments, windowId],
+		{encoding: 'utf8', env: {...process.env, LC_ALL: 'C.utf8'}},
+	);
+	const boundsStdout = childProcess.execFileSync(
+		xwininfoBinary,
+		[...xpropDetailsArguments, windowId],
+		{encoding: 'utf8'},
+	);
 
-  const data = parseLinux({
-    activeWindowId: windowId,
-    boundsStdout,
-    stdout,
-  });
-  data.memoryUsage = getMemoryUsageByPidSync(data.owner.processId);
-  data.owner.path = getPathByPidSync(data.owner.processId);
-  return data;
+	const data = parseLinux({
+		activeWindowId: windowId,
+		boundsStdout,
+		stdout,
+	});
+	data.memoryUsage = getMemoryUsageByPidSync(data.owner.processId);
+	data.owner.path = getPathByPidSync(data.owner.processId);
+	return data;
 }
 
 export async function activeWindow() {
-  try {
-    const { stdout: activeWindowIdStdout } = await execFile(
-      xpropBinary,
-      xpropActiveArguments
-    );
-    const activeWindowId = getActiveWindowId(activeWindowIdStdout);
+	try {
+		const {stdout: activeWindowIdStdout} = await execFile(
+			xpropBinary,
+			xpropActiveArguments,
+		);
+		const activeWindowId = getActiveWindowId(activeWindowIdStdout);
 
-    if (!activeWindowId) {
-      return;
-    }
+		if (!activeWindowId) {
+			return;
+		}
 
-    return getWindowInformation(activeWindowId);
-  } catch {
-    return undefined;
-  }
+		return getWindowInformation(activeWindowId);
+	} catch {
+		return undefined;
+	}
 }
 
 export function activeWindowSync() {
-  try {
-    const activeWindowIdStdout = childProcess.execFileSync(
-      xpropBinary,
-      xpropActiveArguments,
-      { encoding: "utf8" }
-    );
-    const activeWindowId = getActiveWindowId(activeWindowIdStdout);
+	try {
+		const activeWindowIdStdout = childProcess.execFileSync(
+			xpropBinary,
+			xpropActiveArguments,
+			{encoding: 'utf8'},
+		);
+		const activeWindowId = getActiveWindowId(activeWindowIdStdout);
 
-    if (!activeWindowId) {
-      return;
-    }
+		if (!activeWindowId) {
+			return;
+		}
 
-    return getWindowInformationSync(activeWindowId);
-  } catch {
-    return undefined;
-  }
+		return getWindowInformationSync(activeWindowId);
+	} catch {
+		return undefined;
+	}
 }
 
 export async function openWindows() {
-  try {
-    const { stdout: openWindowIdStdout } = await execFile(
-      xpropBinary,
-      xpropOpenArguments
-    );
+	try {
+		const {stdout: openWindowIdStdout} = await execFile(
+			xpropBinary,
+			xpropOpenArguments,
+		);
 
-    // Get open windows Ids
-    const windowsIds = openWindowIdStdout
-      .split("#")[1]
-      .trim()
-      .replace("\n", "")
-      .split(",");
+		// Get open windows Ids
+		const windowsIds = openWindowIdStdout
+			.split('#')[1]
+			.trim()
+			.replace('\n', '')
+			.split(',');
 
-    if (!windowsIds || windowsIds.length === 0) {
-      return;
-    }
+		if (!windowsIds || windowsIds.length === 0) {
+			return;
+		}
 
-    const openWindows = [];
+		const openWindows = [];
 
-    for await (const windowId of windowsIds) {
-      openWindows.push(
-        await getWindowInformation(Number.parseInt(windowId, 16))
-      );
-    }
+		for await (const windowId of windowsIds) {
+			openWindows.push(
+				await getWindowInformation(Number.parseInt(windowId, 16)),
+			);
+		}
 
-    return openWindows;
-  } catch {
-    return undefined;
-  }
+		return openWindows;
+	} catch {
+		return undefined;
+	}
 }
 
 export function openWindowsSync() {
-  try {
-    const openWindowIdStdout = childProcess.execFileSync(
-      xpropBinary,
-      xpropOpenArguments,
-      { encoding: "utf8" }
-    );
-    const windowsIds = openWindowIdStdout
-      .split("#")[1]
-      .trim()
-      .replace("\n", "")
-      .split(",");
+	try {
+		const openWindowIdStdout = childProcess.execFileSync(
+			xpropBinary,
+			xpropOpenArguments,
+			{encoding: 'utf8'},
+		);
+		const windowsIds = openWindowIdStdout
+			.split('#')[1]
+			.trim()
+			.replace('\n', '')
+			.split(',');
 
-    if (!windowsIds || windowsIds.length === 0) {
-      return;
-    }
+		if (!windowsIds || windowsIds.length === 0) {
+			return;
+		}
 
-    const openWindows = [];
+		const openWindows = [];
 
-    for (const windowId of windowsIds) {
-      const windowInformation = getWindowInformationSync(
-        Number.parseInt(windowId, 16)
-      );
-      openWindows.push(windowInformation);
-    }
+		for (const windowId of windowsIds) {
+			const windowInformation = getWindowInformationSync(
+				Number.parseInt(windowId, 16),
+			);
+			openWindows.push(windowInformation);
+		}
 
-    return openWindows;
-  } catch (error) {
-    console.log(error);
-    return undefined;
-  }
+		return openWindows;
+	} catch (error) {
+		console.log(error);
+		return undefined;
+	}
 }


### PR DESCRIPTION
On Linux, certain application names—such as "Meet - ycg-wced-osy \342\200\224 Mozilla Firefox"—contain invalid or non-UTF-8 characters that cause JSON serialization to fail or break parsing logic.

This fix ensures that such application names are properly sanitized or encoded before being processed or serialized, preventing crashes or malformed JSON errors in the package.

Tested on Linux where the issue was reproducible. The updated handling now safely skips or replaces invalid characters, maintaining application stability and consistent behavior across platforms.

fixes #197 